### PR TITLE
Fix missing separator error in Makeoptions

### DIFF
--- a/Makeoptions.in
+++ b/Makeoptions.in
@@ -109,7 +109,7 @@ ifeq ($(MACHINE),macosx)
   FFTWLIB = -L/opt/local/lib -lfftw3
   FFTWINC = -I/opt/local/include
 else
-  abort Unsupported MACHINE=$(MACHINE)
+  $(abort Unsupported MACHINE=$(MACHINE))
 endif
 endif
 endif


### PR DESCRIPTION
I tried compiling, but ran into the following error:
```console
$ make all
DIR bin created
(cd src/gravity; make compile)
make[1]: Entering directory `/scratch/users/adamjs5/Athena-Cversion-version-4.2/src/gravity'
../../Makeoptions:99: *** missing separator.  Stop.
make[1]: Leaving directory `/scratch/users/adamjs5/Athena-Cversion-version-4.2/src/gravity'
make: *** [compile] Error 2
```
With this patch, I can successfully build Athena. However, `make all MACHINE=foobar` doesn't abort, it also compiles successfully, so there may still be logical bugs.